### PR TITLE
Validate Existence of Comic Image Before Sharing

### DIFF
--- a/Classes/SingleComicViewController.m
+++ b/Classes/SingleComicViewController.m
@@ -241,7 +241,7 @@
 	NSMutableArray *activityItems = [NSMutableArray arrayWithCapacity:2];
 	NSURL *comicUrl = [NSURL URLWithString:self.comic.websiteURL];
 	[activityItems addObject:comicUrl];
-	if (self.comic.downloaded) {
+	if (self.comic.downloaded && self.comic.image) {
 		[activityItems addObject:self.comic.image];
 	}
 	


### PR DESCRIPTION
Apparently comic 1608 has no image, and it's crashing the app when you share it. Cool.