### PR TITLE
Convert to NSURLSession

### DIFF
--- a/Classes/ComicListViewController.m
+++ b/Classes/ComicListViewController.m
@@ -63,7 +63,6 @@ static UIImage *downloadImage = nil;
 	[searchBar sizeToFit];
 	searchBar.placeholder = NSLocalizedString(@"Search xkcd", @"Search bar placeholder text");
 	searchBar.autocapitalizationType = UITextAutocapitalizationTypeNone;
-	searchBar.delegate = self;
 	self.tableView.tableHeaderView = searchBar;
 }
 

--- a/Classes/ComicListViewController.m
+++ b/Classes/ComicListViewController.m
@@ -109,7 +109,7 @@ static UIImage *downloadImage = nil;
 	
 	// Set up image fetcher, for the future
 	if (!self.imageFetcher) {
-		self.imageFetcher = [[SingleComicImageFetcher alloc] init];
+		self.imageFetcher = [[SingleComicImageFetcher alloc] initWithURLSession:[NSURLSession sharedSession]];
 		self.imageFetcher.delegate = self;
 	}
 	

--- a/Classes/FetchComicFromWeb.h
+++ b/Classes/FetchComicFromWeb.h
@@ -10,7 +10,10 @@
 
 @interface FetchComicFromWeb : NSOperation
 
-- (instancetype)initWithComicNumber:(NSInteger)comicNumberToFetch completionTarget:(id)completionTarget action:(SEL)completionAction;
+- (instancetype)initWithComicNumber:(NSInteger)comicNumberToFetch
+						 URLSession:(NSURLSession *)URLSession
+				   completionTarget:(id)completionTarget
+							 action:(SEL)completionAction;
 
 @property (nonatomic, readonly) NSInteger comicNumber;
 @property (nonatomic, readonly) NSString *comicName;

--- a/Classes/FetchComicFromWeb.m
+++ b/Classes/FetchComicFromWeb.m
@@ -51,6 +51,10 @@
 		self.comicTitleText = @"";
 		self.comicImageURL = @"http://imgs.xkcd.com/static/xkcdLogo.png"; // anything...
 		self.comicTranscript = @"";
+
+        if (![self isCancelled]) {
+            [self.target performSelectorOnMainThread:self.action withObject:self waitUntilDone:NO];
+        }
 	}
 	else {
 		NSURL *comicURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://www.xkcd.com/%li/info.0.json", (long)self.comicNumber]];
@@ -79,12 +83,13 @@
 					}
 				}
 			}
+
+            if (![self isCancelled]) {
+                [self.target performSelectorOnMainThread:self.action withObject:self waitUntilDone:NO];
+            }
 		}];
 		
 		[self.dataTask resume];
-	}
-	if (![self isCancelled]) {
-		[self.target performSelectorOnMainThread:self.action withObject:self waitUntilDone:NO];
 	}
 }
 

--- a/Classes/FetchComicFromWeb.m
+++ b/Classes/FetchComicFromWeb.m
@@ -22,6 +22,8 @@
 @property (nonatomic) SEL action;
 @property (nonatomic) NSError *error;
 @property (nonatomic) BOOL got404;
+@property (nonatomic) NSURLSession *URLSession;
+@property (nonatomic) NSURLSessionDataTask *dataTask;
 
 @end
 
@@ -29,11 +31,15 @@
 
 @implementation FetchComicFromWeb
 
-- (instancetype)initWithComicNumber:(NSInteger)comicNumberToFetch completionTarget:(id)completionTarget action:(SEL)completionAction {
+- (instancetype)initWithComicNumber:(NSInteger)comicNumberToFetch
+						 URLSession:(NSURLSession *)URLSession
+				   completionTarget:(id)completionTarget
+							 action:(SEL)completionAction {
 	if (self = [super init]) {
 		_comicNumber = comicNumberToFetch;
 		_target = completionTarget;
 		_action = completionAction;
+		_URLSession = URLSession;
 	}
 	return self;
 }
@@ -50,26 +56,32 @@
 		NSURL *comicURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://www.xkcd.com/%li/info.0.json", (long)self.comicNumber]];
 		NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:comicURL];
 		[request setValue:kUseragent forHTTPHeaderField:@"User-Agent"];
-		NSHTTPURLResponse *response = nil;
-		NSError *requestError = nil;
-		NSData *comicData = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&requestError];
-		self.got404 = [response statusCode] == 404;
-		if (!self.got404) {
-			self.error = requestError;
-			if (!requestError) {
-				NSError *parseError = nil;
-				NSData *fixedData = [comicData dataByFixingFuckedUpUnicodeInJSON];
-				NSDictionary *comicDictionary = [NSJSONSerialization JSONObjectWithData:fixedData options:0 error:&parseError];
-				self.error = parseError;
-				if (!parseError && [comicDictionary isKindOfClass:[NSDictionary class]]) {
-					self.comicName = [NSString stringByCleaningHTML:[comicDictionary stringForKey:@"title"]];
-					self.comicTitleText = [NSString stringByCleaningHTML:[comicDictionary stringForKey:@"alt"]];
-					self.comicImageURL = [NSString stringByCleaningHTML:[comicDictionary stringForKey:@"img"]];
-					self.comicTranscript = [comicDictionary stringForKey:@"transcript"];
-					// TODO: use link/news to detect "large version" image urls
+		
+		self.dataTask = [self.URLSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+			if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+				NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+				self.got404 = statusCode == 404;
+			}
+			
+			if (!self.got404) {
+				self.error = error;
+				if (!error) {
+					NSError *parseError = nil;
+					NSData *fixedData = [data dataByFixingFuckedUpUnicodeInJSON];
+					NSDictionary *comicDictionary = [NSJSONSerialization JSONObjectWithData:fixedData options:0 error:&parseError];
+					self.error = parseError;
+					if (!parseError && [comicDictionary isKindOfClass:[NSDictionary class]]) {
+						self.comicName = [NSString stringByCleaningHTML:[comicDictionary stringForKey:@"title"]];
+						self.comicTitleText = [NSString stringByCleaningHTML:[comicDictionary stringForKey:@"alt"]];
+						self.comicImageURL = [NSString stringByCleaningHTML:[comicDictionary stringForKey:@"img"]];
+						self.comicTranscript = [comicDictionary stringForKey:@"transcript"];
+						// TODO: use link/news to detect "large version" image urls
+					}
 				}
 			}
-		}
+		}];
+		
+		[self.dataTask resume];
 	}
 	if (![self isCancelled]) {
 		[self.target performSelectorOnMainThread:self.action withObject:self waitUntilDone:NO];

--- a/Classes/FetchComicImageFromWeb.h
+++ b/Classes/FetchComicImageFromWeb.h
@@ -12,6 +12,7 @@
 
 - (instancetype)initWithComicNumber:(NSInteger)number
 						   imageURL:(NSURL *)imageURL
+                         URLSession:(NSURLSession *)session
 				   completionTarget:(id)completionTarget
 							 action:(SEL)completionAction
 							context:(id)context;

--- a/Classes/FetchComicImageFromWeb.m
+++ b/Classes/FetchComicImageFromWeb.m
@@ -54,7 +54,7 @@
 
     TLDebugLog(@"Fetching image at %@", self.comicImageURL);
 
-    [self.URLSession dataTaskWithRequest:request
+    [[self.URLSession dataTaskWithRequest:request
                        completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
                            self.comicImageData = data;
                            self.error = error;
@@ -68,7 +68,8 @@
                                                              withObject:self
                                                           waitUntilDone:NO];
                            }
-                       }];
+                       }
+      ] resume];
 }
 
 @end

--- a/Classes/FetchComicImageFromWeb.m
+++ b/Classes/FetchComicImageFromWeb.m
@@ -21,6 +21,7 @@
 @property (nonatomic) SEL action;
 @property (nonatomic) NSError *error;
 @property (nonatomic) id context;
+@property (nonatomic) NSURLSession *URLSession;
 
 @end
 
@@ -29,41 +30,45 @@
 @implementation FetchComicImageFromWeb
 
 - (instancetype)initWithComicNumber:(NSInteger)number
-						   imageURL:(NSURL *)imageURL
-				   completionTarget:(id)completionTarget
-							 action:(SEL)completionAction
-							context:(id)aContext {
-	if(self = [super init]) {
-		_comicNumber = number;
-		_comicImageURL = imageURL;
-		_target = completionTarget;
-		_action = completionAction;
-		_context = aContext;
-	}
-	return self;
+                           imageURL:(NSURL *)imageURL
+                         URLSession:(NSURLSession *)session
+                   completionTarget:(id)completionTarget
+                             action:(SEL)completionAction
+                            context:(id)aContext {
+    if(self = [super init]) {
+        _comicNumber = number;
+        _comicImageURL = imageURL;
+        _target = completionTarget;
+        _action = completionAction;
+        _context = aContext;
+        _URLSession = session;
+    }
+    return self;
 }
 
 - (void)main {
-	NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.comicImageURL
-																cachePolicy:NSURLRequestUseProtocolCachePolicy
-															timeoutInterval:180.0f];
-	[request setValue:kUseragent forHTTPHeaderField:@"User-Agent"];
-	NSURLResponse *response = nil;
-	NSError *requestError = nil;
-	TLDebugLog(@"Fetching image at %@", self.comicImageURL);
-	self.comicImageData = [NSURLConnection sendSynchronousRequest:request
-												returningResponse:&response
-															error:&requestError];
-	self.error = requestError;
-	if (self.error) {
-		TLDebugLog(@"Image fetch completed with error: %@", self.error);
-	}
-	
-	if(![self isCancelled]) {
-    [self.target performSelectorOnMainThread:self.action
-                                  withObject:self
-                               waitUntilDone:NO];
-  }
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.comicImageURL
+                                                                cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                            timeoutInterval:180.0f];
+    [request setValue:kUseragent forHTTPHeaderField:@"User-Agent"];
+
+    TLDebugLog(@"Fetching image at %@", self.comicImageURL);
+
+    [self.URLSession dataTaskWithRequest:request
+                       completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                           self.comicImageData = data;
+                           self.error = error;
+
+                           if (self.error) {
+                               TLDebugLog(@"Image fetch completed with error: %@", self.error);
+                           }
+
+                           if(![self isCancelled]) {
+                               [self.target performSelectorOnMainThread:self.action
+                                                             withObject:self
+                                                          waitUntilDone:NO];
+                           }
+                       }];
 }
 
 @end

--- a/Classes/NewComicFetcher.m
+++ b/Classes/NewComicFetcher.m
@@ -27,6 +27,7 @@
 
 @property (nonatomic) NSOperationQueue *fetchQueue;
 @property (nonatomic) NSMutableArray *comicsToInsert;
+@property (nonatomic) NSURLSession *URLSession;
 
 @end
 
@@ -38,12 +39,14 @@
 	if (self = [super init]) {
 		_fetchQueue = [[NSOperationQueue alloc] init];
 		_comicsToInsert = [NSMutableArray arrayWithCapacity:kInsertChunkSize];
+		_URLSession = [NSURLSession sharedSession];
 	}
 	return self;
 }
 
 - (void)fetchComic:(NSInteger)comicNumber {
 	FetchComicFromWeb *fetchOperation = [[FetchComicFromWeb alloc] initWithComicNumber:comicNumber
+																			URLSession:self.URLSession
 																	  completionTarget:self
 																				action:@selector(didCompleteFetchOperation:)];
 	[self.fetchQueue addOperation:fetchOperation];

--- a/Classes/SingleComicImageFetcher.h
+++ b/Classes/SingleComicImageFetcher.h
@@ -11,6 +11,15 @@
 
 @interface SingleComicImageFetcher : NSObject
 
+/**
+ *  Fetches an image for the supplied comic.
+ *
+ *  @param comic   The Comic to fetch an image for.
+ *  @param context An arbitrary @c id type.
+ *
+ *  @note @c context is currently used as a flag to open the comic after it is downloaded.
+ *  Probably want to rethink this architecture in the future.
+ */
 - (void)fetchImageForComic:(Comic *)comic context:(id)context;
 - (void)fetchImagesForAllComics;
 - (BOOL)downloadingAll;

--- a/Classes/SingleComicImageFetcher.h
+++ b/Classes/SingleComicImageFetcher.h
@@ -12,9 +12,18 @@
 @interface SingleComicImageFetcher : NSObject
 
 /**
- *  Fetches an image for the supplied comic.
+ *  Initializes a @c SingleComicImageFetcher.
  *
- *  @param comic   The Comic to fetch an image for.
+ *  @param session The @c NSURLSession to use when downloading the image.
+ *
+ *  @return An initialized @c SingleComicImageFetcher.
+ */
+- (instancetype)initWithURLSession:(NSURLSession *)session;
+
+/**
+ *  Fetches an image for the supplied @c Comic.
+ *
+ *  @param comic   The @c Comic to fetch an image for.
  *  @param context An arbitrary @c id type.
  *
  *  @note @c context is currently used as a flag to open the comic after it is downloaded.

--- a/Classes/SingleComicImageFetcher.m
+++ b/Classes/SingleComicImageFetcher.m
@@ -22,6 +22,7 @@
 @property (nonatomic) id keepInMemory;
 @property (nonatomic) NSOperationQueue *fetchQueue;
 @property (nonatomic) NSMutableArray *comicsRemainingDuringDownloadAll;
+@property (nonatomic) NSURLSession *URLSession;
 
 @end
 
@@ -29,9 +30,10 @@
 
 @implementation SingleComicImageFetcher
 
-- (instancetype)init {
+- (instancetype)initWithURLSession:(NSURLSession *)session {
   if (self = [super init]) {
-    _fetchQueue = [[NSOperationQueue alloc] init];
+      _fetchQueue = [[NSOperationQueue alloc] init];
+      _URLSession = session;
   }
   return self;
 }
@@ -41,6 +43,7 @@
     NSURL *comicImageURL = [NSURL URLWithString:comic.imageURL];
     FetchComicImageFromWeb *fetchOperation = [[FetchComicImageFromWeb alloc] initWithComicNumber:[comic.number integerValue]
                                                                                          imageURL:comicImageURL
+                                                                                      URLSession:self.URLSession
                                                                                  completionTarget:self
                                                                                            action:@selector(didCompleteFetchOperation:)
                                                                                           context:context];

--- a/Classes/SingleComicViewController.m
+++ b/Classes/SingleComicViewController.m
@@ -93,10 +93,12 @@
   }
 }
 
-- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
-{
-	[super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
-	[self calculateZoomScaleAndAnimate:YES];
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        [self calculateZoomScaleAndAnimate:YES];
+    } completion:nil];
 }
 
 - (void)setupToolbar {

--- a/Classes/SingleComicViewController.m
+++ b/Classes/SingleComicViewController.m
@@ -87,7 +87,7 @@
     [self displayComicImage];    
   } else {
 	  [self displayLoadingView];
-	  self.imageFetcher = [[SingleComicImageFetcher alloc] init];
+	  self.imageFetcher = [[SingleComicImageFetcher alloc] initWithURLSession:[NSURLSession sharedSession]];
 	  self.imageFetcher.delegate = self;
 	  [self.imageFetcher fetchImageForComic:self.comic context:nil];
   }

--- a/Classes/SingleComicViewController.m
+++ b/Classes/SingleComicViewController.m
@@ -303,10 +303,10 @@
 
 - (void)showTitleText:(UILongPressGestureRecognizer *)recognizer {
 	if (recognizer.state == UIGestureRecognizerStateBegan) {
-		UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil message:self.comic.titleText preferredStyle:UIAlertControllerStyleAlert];
+		UIAlertController *alertController = [UIAlertController alertControllerWithTitle:self.comic.name message:self.comic.titleText preferredStyle:UIAlertControllerStyleAlert];
 		[alertController addAction:
 		 [UIAlertAction actionWithTitle:NSLocalizedString(@"Ok", @"Confirmation action title.")
-								  style:UIAlertActionStyleDefault
+								  style:UIAlertActionStyleCancel
 								handler:^(UIAlertAction * _Nonnull action) {}]
 		];
 		[self presentViewController:alertController animated:YES completion:nil];


### PR DESCRIPTION
Removes the deprecated synchronous data call warnings by upgrading this to the newest iOS networking stack.