### PR TITLE
Fix issue where the app crashes whenever the user tries to save an image

### DIFF
--- a/xkcd-Info.plist
+++ b/xkcd-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>To save xkcd images to your photo library.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Adds NSPhotoLibraryAddUsageDescription to the Info.plist.