### PR TITLE
High-resolution images

### DIFF
--- a/Classes/FetchComicFromWeb.m
+++ b/Classes/FetchComicFromWeb.m
@@ -77,7 +77,6 @@
 						self.comicTitleText = [NSString stringByCleaningHTML:[comicDictionary stringForKey:@"alt"]];
 						self.comicImageURL = [NSString stringByCleaningHTML:[comicDictionary stringForKey:@"img"]];
 						self.comicTranscript = [comicDictionary stringForKey:@"transcript"];
-						// TODO: use link/news to detect "large version" image urls
 					}
 				}
 			}

--- a/Classes/FetchComicImageFromWeb.h
+++ b/Classes/FetchComicImageFromWeb.h
@@ -11,7 +11,7 @@
 @interface FetchComicImageFromWeb : NSOperation
 
 - (instancetype)initWithComicNumber:(NSInteger)number
-						   imageURL:(NSURL *)imageURL
+						   imageURL:(NSString *)imageURL
                          URLSession:(NSURLSession *)session
 				   completionTarget:(id)completionTarget
 							 action:(SEL)completionAction

--- a/Classes/FetchComicImageFromWeb.m
+++ b/Classes/FetchComicImageFromWeb.m
@@ -15,22 +15,25 @@
 @interface FetchComicImageFromWeb ()
 
 @property (nonatomic) NSInteger comicNumber;
-@property (nonatomic) NSURL *comicImageURL;
+@property (nonatomic) NSString *comicImageURL;
 @property (nonatomic) NSData *comicImageData;
 @property (nonatomic, weak) id target;
 @property (nonatomic) SEL action;
 @property (nonatomic) NSError *error;
 @property (nonatomic) id context;
 @property (nonatomic) NSURLSession *URLSession;
+@property (nonatomic) bool tryLarge;
+@property (nonatomic) bool try2x;
 
 @end
 
 #pragma mark -
 
+
 @implementation FetchComicImageFromWeb
 
 - (instancetype)initWithComicNumber:(NSInteger)number
-                           imageURL:(NSURL *)imageURL
+                           imageURL:(NSString *)imageURL
                          URLSession:(NSURLSession *)session
                    completionTarget:(id)completionTarget
                              action:(SEL)completionAction
@@ -46,29 +49,129 @@
     return self;
 }
 
+- (NSString *)addSuffixToURL:(NSString *)url
+                      suffix:(NSString *)suffix {
+    NSString *extension = [url pathExtension];
+    if ([extension length] == 0) {
+        return [url stringByAppendingString:suffix];
+    }
+    NSString *withoutExtension = [url substringToIndex:([url length] - [extension length] - 1)];
+    NSString *withSuffix = [withoutExtension stringByAppendingString:suffix];
+    return [[withSuffix stringByAppendingString:@"."] stringByAppendingString:extension];
+}
+
 - (void)main {
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.comicImageURL
+    // self.comicImageURL is the image url given by the xkcd API.
+    // It is usually the lowest resolution image available. This
+    // code uses some hard-coded special cases as well as trial
+    // and error to find the best image available. It's best to
+    // do this here and not in the NewComicFetcher because it
+    // reduces the number of image requests sent to xkcd servers
+    // during inital app load, and also older users who have
+    // already loaded all comics can get the high-res version
+    // simply by redownloading a single comic instead of having
+    // to redownload the whole app to refresh the comic list.
+    
+    self.tryLarge = false;
+    // 1084 is the first comic to have a 2x version
+    // Some comics have large, some have 2x,
+    // some have both, some have neither.
+    self.try2x = (self.comicNumber >= 1084);
+    
+    // Special cases
+    if (self.comicNumber == 256) {
+        [self doFetch:@"https://imgs.xkcd.com/comics/online_communities.png"];
+        return;
+    } else if (self.comicNumber == 273) {
+        [self doFetch:@"https://imgs.xkcd.com/comics/electromagnetic_spectrum.png"];
+        return;
+    }
+//    else if (self.comicNumber == 980) {
+//        // TODO: This image is only ~7MB, but attempting to
+//        // display it results in gigabytes of memory usage.
+//        // Not sure if a bug in Apple's image view or in
+//        // this app.
+//        [self doFetch:@"https://imgs.xkcd.com/comics/money_huge.png"];
+//        return;
+    else if (self.comicNumber <= 2189) { // Newest comic at time of writing
+        // Hardcode known "large" comics up until a specific point.
+        // This is not necessary, but avoids extra image lookups
+        // and spam to xkcd servers.
+        switch (self.comicNumber) {
+            case 657:  case 681:  case 802:  case 832:
+            case 850:  case 930:  case 1000: case 1040:
+            case 1071: case 1079: case 1080: case 1127:
+            case 1196: case 1212: case 1256: case 1298:
+            case 1389: case 1392: case 1407: case 1461:
+            case 1491: case 1509: case 1688: case 1939:
+            case 1970:
+                self.tryLarge = true;
+                break;
+        }
+    } else {
+        // Check for large on all newer comics.
+        self.tryLarge = true;
+    }
+    
+    [self doFetch:@""];
+}
+
+- (void)doFetch:(NSString *)specialURL {
+    bool special = ![specialURL isEqualToString:@""];
+    NSString *url;
+    
+    if (special) {
+        url = specialURL;
+    } else if (self.tryLarge) {
+        url = [self addSuffixToURL:self.comicImageURL suffix:@"_large"];
+    } else if (self.try2x) {
+        url = [self addSuffixToURL:self.comicImageURL suffix:@"_2x"];
+    } else {
+        url = self.comicImageURL;
+    }
+    
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]
                                                                 cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                             timeoutInterval:180.0f];
     [request setValue:[Constants userAgent] forHTTPHeaderField:@"User-Agent"];
-
-    TLDebugLog(@"Fetching image at %@", self.comicImageURL);
-
+    
+    TLDebugLog(@"Fetching image at %@", url);
+    
     [[self.URLSession dataTaskWithRequest:request
-                       completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-                           self.comicImageData = data;
-                           self.error = error;
-
-                           if (self.error) {
-                               TLDebugLog(@"Image fetch completed with error: %@", self.error);
-                           }
-
-                           if(![self isCancelled]) {
-                               [self.target performSelectorOnMainThread:self.action
-                                                             withObject:self
-                                                          waitUntilDone:NO];
-                           }
-                       }
+                        completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                            self.comicImageData = data;
+                            self.error = error;
+                            
+                            if (self.error) {
+                                TLDebugLog(@"Image fetch completed with error: %@", self.error);
+                            } else if (response
+                                       && [response isKindOfClass:[NSHTTPURLResponse class]]
+                                       && [((NSHTTPURLResponse *)response) statusCode] == 404) {
+                                TLDebugLog(@"Image fetch completed with 404");
+                                
+                                if (special) {
+                                    [self doFetch:@""];
+                                    return;
+                                } else if (self.tryLarge) {
+                                    self.tryLarge = false;
+                                    [self doFetch:@""];
+                                    return;
+                                } else if (self.try2x) {
+                                    self.try2x = false;
+                                    [self doFetch:@""];
+                                    return;
+                                } else {
+                                    // Failed to find default image. Right now
+                                    // this just results in an empty screen.
+                                }
+                            }
+                            
+                            if(![self isCancelled]) {
+                                [self.target performSelectorOnMainThread:self.action
+                                                              withObject:self
+                                                           waitUntilDone:NO];
+                            }
+                        }
       ] resume];
 }
 

--- a/Classes/SingleComicImageFetcher.m
+++ b/Classes/SingleComicImageFetcher.m
@@ -40,9 +40,8 @@
 
 - (void)fetchImageForComic:(Comic *)comic context:(id)context {
   if (comic.imageURL) {
-    NSURL *comicImageURL = [NSURL URLWithString:comic.imageURL];
     FetchComicImageFromWeb *fetchOperation = [[FetchComicImageFromWeb alloc] initWithComicNumber:[comic.number integerValue]
-                                                                                         imageURL:comicImageURL
+                                                                                         imageURL:comic.imageURL
                                                                                       URLSession:self.URLSession
                                                                                  completionTarget:self
                                                                                            action:@selector(didCompleteFetchOperation:)


### PR DESCRIPTION
Fix for #68. I did my best to add high-resolution image support in a way that a) didn't require huge changes to how the app works and b) minimizes requests to xkcd servers.

Unfortunately there is no way (that I could find) to determine the high-resolution image URL to use. Some comics use the default `img` URL, some use the `img` but with `_large` at the end (those are usually the ones that the xkcd.com comic image is a link to a larger version), and almost every comic >= 1084 has a `_2x` version (the only ones without `_2x` are some of the ones that use `_large`).

So my change will, on loading the image, attempt `_large`, then attempt `_2x`, then fall back to the default image URL. However, to minimize requests, I have hardcoded known comics that are `_large` up to current date, so it doesn't have to check for the vast majority that aren't. *This doesn't need to be updated* -- future comics not included in the hardcoded part will just always check for `_large` first. Sorry it's so ugly, but I'm not sure there's a better way to do it, since the xkcd API is so useless for high-res images.

Also comics 256 and 273 are special -- their default image URL has `_small` at the end, but the link is to one with no suffix. I just hard-coded these URLs. It will still fall back to the default URL if my hard-coded URL fails.

Additionally, since the 2x comics are bigger, I modified the view controller to zoom out to 0.5 when loading comics >= 1084. That way, they don't show up super big on screen by default. (While doing this, I also fixed the "Open Zoomed Out" feature, which did not seem to be working originally.)