### PR TITLE
Download retina images if they exist

### DIFF
--- a/Classes/FetchComicImageFromWeb.h
+++ b/Classes/FetchComicImageFromWeb.h
@@ -18,6 +18,7 @@
 							context:(id)context;
 
 @property (nonatomic, readonly) NSData *comicImageData;
+@property (nonatomic, readonly) BOOL isRetinaImage;
 @property (nonatomic, readonly) NSInteger comicNumber;
 @property (nonatomic, readonly) NSError *error;
 @property (nonatomic, readonly) id context;

--- a/Classes/FetchComicImageFromWeb.m
+++ b/Classes/FetchComicImageFromWeb.m
@@ -16,7 +16,9 @@
 
 @property (nonatomic) NSInteger comicNumber;
 @property (nonatomic) NSURL *comicImageURL;
+@property (nonatomic) NSURL *potentialRetinaImageURL;
 @property (nonatomic) NSData *comicImageData;
+@property (nonatomic) BOOL isRetinaImage;
 @property (nonatomic, weak) id target;
 @property (nonatomic) SEL action;
 @property (nonatomic) NSError *error;
@@ -42,34 +44,70 @@
         _action = completionAction;
         _context = aContext;
         _URLSession = session;
+        
+        if ([self shouldAttemptToDownloadRetinaImage]) {
+            NSString *originalImageURL = self.comicImageURL.absoluteString;
+            NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\b(.+)(\\.\\w+)\\b" options:0 error:nil];
+            NSString *potentialRetinaImageURLString = [regex stringByReplacingMatchesInString:originalImageURL options:0 range:NSMakeRange(0, originalImageURL.length) withTemplate:@"$1_2x$2"];
+            _potentialRetinaImageURL = [[NSURL alloc] initWithString:potentialRetinaImageURLString];
+        }
     }
     return self;
 }
 
 - (void)main {
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.comicImageURL
+    if (self.potentialRetinaImageURL) {
+        [self requestRetinaImage];
+    }
+}
+
+- (void)requestRetinaImage {
+    [self requestImage:self.potentialRetinaImageURL completion:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        if (error) {
+            [self requestNonRetinaImage];
+        } else {
+            self.isRetinaImage = YES;
+            [self completeRequestWithComicImageData:data error:nil];
+        }
+    }];
+}
+
+- (void) requestNonRetinaImage {
+    [self requestImage:self.comicImageURL completion:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        [self completeRequestWithComicImageData:data error:error];
+    }];
+}
+
+- (void)requestImage:(NSURL *)imageURL completion:(void (^)(NSData *, NSURLResponse *, NSError *))completion {
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:imageURL
                                                                 cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                             timeoutInterval:180.0f];
     [request setValue:[Constants userAgent] forHTTPHeaderField:@"User-Agent"];
 
-    TLDebugLog(@"Fetching image at %@", self.comicImageURL);
+    TLDebugLog(@"Fetching image at %@", imageURL);
 
     [[self.URLSession dataTaskWithRequest:request
-                       completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-                           self.comicImageData = data;
-                           self.error = error;
-
-                           if (self.error) {
-                               TLDebugLog(@"Image fetch completed with error: %@", self.error);
-                           }
-
-                           if(![self isCancelled]) {
-                               [self.target performSelectorOnMainThread:self.action
-                                                             withObject:self
-                                                          waitUntilDone:NO];
-                           }
-                       }
+                       completionHandler:completion
       ] resume];
+}
+
+- (void)completeRequestWithComicImageData:(NSData *)data error:(NSError *)error {
+    self.comicImageData = data;
+    self.error = error;
+
+    if (self.error) {
+        TLDebugLog(@"Image fetch completed with error: %@", self.error);
+    }
+
+    if(![self isCancelled]) {
+        [self.target performSelectorOnMainThread:self.action
+                                      withObject:self
+                                   waitUntilDone:NO];
+    }
+}
+
+- (BOOL)shouldAttemptToDownloadRetinaImage {
+    return _comicNumber >= 1053; // https://xkcd.com/1053/ is the first comic that shows up with a retina version
 }
 
 @end

--- a/Classes/FetchComicImageFromWeb.m
+++ b/Classes/FetchComicImageFromWeb.m
@@ -64,6 +64,9 @@
 - (void)requestRetinaImage {
     [self requestImage:self.potentialRetinaImageURL completion:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         if (error) {
+            TLDebugLog(@"Retina image fetch failed with error: %@", self.error);
+            TLDebugLog(@"Requesting non-retina image for comic %li", (long)self.comicNumber);
+
             [self requestNonRetinaImage];
         } else {
             self.isRetinaImage = YES;

--- a/Classes/FetchComicImageFromWeb.m
+++ b/Classes/FetchComicImageFromWeb.m
@@ -112,7 +112,11 @@
 }
 
 - (BOOL)shouldAttemptToDownloadRetinaImage {
-    return _comicNumber >= 1053; // https://xkcd.com/1053/ is the first comic that shows up with a retina version
+    // https://xkcd.com/1053/ is the first comic that shows up with a retina version
+    return self.comicNumber >= 1053
+        // these comics don't work via the API at all, so don't bother trying to download the retina image
+        && self.comicNumber != 1663 // https://xkcd.com/1663/
+        && self.comicNumber != 1608; // https://xkcd.com/1608/
 }
 
 @end

--- a/Classes/FetchComicImageFromWeb.m
+++ b/Classes/FetchComicImageFromWeb.m
@@ -58,6 +58,8 @@
 - (void)main {
     if (self.potentialRetinaImageURL) {
         [self requestRetinaImage];
+    } else {
+        [self requestNonRetinaImage];
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/paulrehkugler/xkcd/issues/68.

The retina image is not included in the API response so I am assuming a `${filename}_2x${extension}` version of the image exists. If it fails to download, we default to the non-retina version.

Note that this will only apply to images that have not yet been downloaded. I also added a helper so that we don't attempt to download retina images on old comics that don't have one. I scrolled through xkcd.com and found that retina versions started with https://xkcd.com/1053/.